### PR TITLE
Add Windows WASM/Android build helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The aim is to provide a small alternative to the offical companion apps (hence L
 
 
 ## Status
-Planning → initial scaffolding in progress.
+Planning -> initial scaffolding in progress.
 
 ## Quick Start
 
@@ -34,8 +34,7 @@ zig build run
 ./.tools/emsdk/emsdk install latest
 ./.tools/emsdk/emsdk activate latest
 
-# Build
-zig build -Dwasm=true
+# Build (Windows: run scripts/patch-zemscripten.ps1 once after fetch)\nzig build -Dwasm=true
 ```
 
 Outputs are installed under `zig-out/web/`.

--- a/build.zig
+++ b/build.zig
@@ -267,8 +267,10 @@ pub fn build(b: *std.Build) void {
         });
         emcc_step.dependOn(&web_assets.step);
 
-        const chmod_emcc = b.addSystemCommand(&.{ "chmod", "+x", zemscripten_build.emccPath(b) });
-        emcc_step.dependOn(&chmod_emcc.step);
+        if (target.result.os.tag != .windows) {
+            const chmod_emcc = b.addSystemCommand(&.{ "chmod", "+x", zemscripten_build.emccPath(b) });
+            emcc_step.dependOn(&chmod_emcc.step);
+        }
 
         b.getInstallStep().dependOn(emcc_step);
     }

--- a/scripts/android-env.ps1
+++ b/scripts/android-env.ps1
@@ -1,0 +1,21 @@
+param(
+    [string]$JavaHome = "C:\Program Files\Eclipse Adoptium\jdk-17.0.17.10-hotspot",
+    [string]$AndroidSdkRoot = "$env:LOCALAPPDATA\Android\Sdk"
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $JavaHome)) {
+    throw "JAVA_HOME not found at $JavaHome"
+}
+if (-not (Test-Path $AndroidSdkRoot)) {
+    throw "ANDROID_SDK_ROOT not found at $AndroidSdkRoot"
+}
+
+$env:JAVA_HOME = $JavaHome
+$env:ANDROID_SDK_ROOT = $AndroidSdkRoot
+$env:ANDROID_HOME = $AndroidSdkRoot
+$env:PATH = "$env:JAVA_HOME\bin;$env:ANDROID_SDK_ROOT\platform-tools;$env:PATH"
+
+Write-Host "JAVA_HOME=$env:JAVA_HOME"
+Write-Host "ANDROID_SDK_ROOT=$env:ANDROID_SDK_ROOT"

--- a/scripts/build-android.ps1
+++ b/scripts/build-android.ps1
@@ -1,0 +1,16 @@
+param(
+    [string]$JavaHome = "C:\Program Files\Eclipse Adoptium\jdk-17.0.17.10-hotspot",
+    [string]$AndroidSdkRoot = "$env:LOCALAPPDATA\Android\Sdk"
+)
+
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot "android-env.ps1") -JavaHome $JavaHome -AndroidSdkRoot $AndroidSdkRoot
+
+$root = Resolve-Path (Join-Path $PSScriptRoot "..")
+$zig = Join-Path $root ".tools\zig-0.15.2\zig.exe"
+if (-not (Test-Path $zig)) {
+    throw "Zig toolchain not found at $zig"
+}
+
+& $zig build -Dandroid=true

--- a/scripts/build-wasm.ps1
+++ b/scripts/build-wasm.ps1
@@ -1,0 +1,13 @@
+param(
+    [string]$BashPath = "C:\Program Files\Git\bin\bash.exe"
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $BashPath)) {
+    throw "Git Bash not found at $BashPath"
+}
+
+. (Join-Path $PSScriptRoot "patch-zemscripten.ps1")
+
+& $BashPath -lc "source ./scripts/emsdk-env.sh && ./.tools/zig-0.15.2/zig.exe build -Dwasm=true"

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -1,0 +1,31 @@
+param(
+    [int]$Retries = 2
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Resolve-Path (Join-Path $PSScriptRoot '..')
+$zig = Join-Path $root '.tools\\zig-0.15.2\\zig.exe'
+
+if (-not (Test-Path $zig)) {
+    throw "Zig toolchain not found at $zig"
+}
+
+$attempt = 0
+$lastExit = 0
+do {
+    $attempt++
+    Write-Host "Windows build attempt $attempt of $($Retries + 1) ..."
+    & $zig build -Dtarget=x86_64-windows-gnu
+    $lastExit = $LASTEXITCODE
+    if ($lastExit -eq 0) { break }
+    Start-Sleep -Seconds 2
+} while ($attempt -le $Retries)
+
+if ($lastExit -ne 0) {
+    throw "Windows build failed after $attempt attempt(s)."
+}
+
+$client = Join-Path $root 'zig-out\\bin\\ziggystarclaw-client.exe'
+$cli = Join-Path $root 'zig-out\\bin\\ziggystarclaw-cli.exe'
+if (-not (Test-Path $client)) { Write-Warning "Missing artifact: $client" }
+if (-not (Test-Path $cli)) { Write-Warning "Missing artifact: $cli" }

--- a/scripts/emsdk-env.sh
+++ b/scripts/emsdk-env.sh
@@ -2,7 +2,33 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Ensure a usable python is on PATH for emsdk when running under MSYS/Git Bash.
+if [[ -d "${ROOT_DIR}/.tools/emsdk/python" ]]; then
+  PY_SUBDIR="$(ls -1 "${ROOT_DIR}/.tools/emsdk/python" | head -n 1)"
+  if [[ -n "${PY_SUBDIR}" ]]; then
+    PY_DIR="${ROOT_DIR}/.tools/emsdk/python/${PY_SUBDIR}"
+    if command -v cygpath >/dev/null 2>&1; then
+      PY_DIR="$(cygpath -u "${PY_DIR}")"
+    fi
+    if [[ -f "${PY_DIR}/python.exe" ]]; then
+      export EMSDK_PYTHON="${PY_DIR}/python.exe"
+    fi
+    export PATH="${PY_DIR}:${PATH}"
+  fi
+fi
 source "${ROOT_DIR}/.tools/emsdk/emsdk_env.sh" >/dev/null 2>&1
+
+# Ensure EMSDK_PYTHON uses a Windows path so emcc.bat can launch it.
+if [[ -n "${EMSDK_PYTHON-}" ]]; then
+  if command -v wslpath >/dev/null 2>&1; then
+    EMSDK_PYTHON="$(wslpath -w "${EMSDK_PYTHON}")"
+    export EMSDK_PYTHON
+  elif command -v cygpath >/dev/null 2>&1; then
+    EMSDK_PYTHON="$(cygpath -w "${EMSDK_PYTHON}")"
+    export EMSDK_PYTHON
+  fi
+fi
 
 # Print a short status when run directly.
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/scripts/patch-zemscripten.ps1
+++ b/scripts/patch-zemscripten.ps1
@@ -1,0 +1,43 @@
+param(
+    [string]$ZigCacheRoot = "$env:LOCALAPPDATA\\zig\\p"
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $ZigCacheRoot)) {
+    throw "Zig cache root not found at $ZigCacheRoot"
+}
+
+$candidates = Get-ChildItem -Directory -Path $ZigCacheRoot -Filter "zemscripten-*"
+if (-not $candidates) {
+    throw "No zemscripten packages found in $ZigCacheRoot. Run 'zig build --fetch' first."
+}
+
+$target = $candidates | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$buildPath = Join-Path $target.FullName "build.zig"
+
+if (-not (Test-Path $buildPath)) {
+    throw "build.zig not found in $($target.FullName)"
+}
+
+$content = Get-Content -Raw $buildPath
+if ($content -match "emcc\\.bat") {
+    Write-Host "zemscripten already patched at $buildPath"
+    return
+}
+
+$pattern = '"emcc\.py",'
+$replacement = @"
+        switch (builtin.target.os.tag) {
+            .windows => "emcc.bat",
+            else => "emcc.py",
+        },
+"@
+
+if ($content -notmatch $pattern) {
+    throw "Could not find emcc.py path in $buildPath"
+}
+
+$content = $content -replace $pattern, $replacement
+Set-Content -Path $buildPath -Value $content -NoNewline
+Write-Host "Patched zemscripten at $buildPath"


### PR DESCRIPTION
## Summary
- add PowerShell helpers for Android and WASM builds
- add zemscripten cache patch script for emcc.bat on Windows
- update emsdk env script and README WASM notes

## Testing
- ./.tools/zig-0.15.2/zig.exe build
- ./.tools/zig-0.15.2/zig.exe build -Dtarget=x86_64-windows-gnu
- ./scripts/build-wasm.ps1
- ./scripts/build-android.ps1