### PR TITLE
UI v2 docking workspace

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -69,9 +69,14 @@ pub fn build(b: *std.Build) void {
         native_exe.root_module.addOptions("build_options", build_options);
 
         native_exe.root_module.addIncludePath(b.path("src"));
+        native_exe.root_module.addIncludePath(zgui_pkg.path("libs/imgui"));
         native_exe.root_module.addCSourceFile(.{
             .file = b.path("src/icon_loader.c"),
             .flags = &.{},
+        });
+        native_exe.root_module.addCSourceFile(.{
+            .file = b.path("src/imgui_ini_bridge.cpp"),
+            .flags = &.{ "-std=c++17" },
         });
 
         const zgui_imgui = zgui_pkg.artifact("imgui");
@@ -242,6 +247,7 @@ pub fn build(b: *std.Build) void {
             "-DIMGUI_IMPL_API=extern \"C\"",
             "-fno-sanitize=undefined",
             "-DIMGUI_DISABLE_OBSOLETE_FUNCTIONS",
+            "-std=c++17",
         };
         wasm.root_module.addCSourceFile(.{
             .file = zgui_wasm_pkg.path("libs/imgui/backends/imgui_impl_glfw.cpp"),
@@ -265,6 +271,10 @@ pub fn build(b: *std.Build) void {
         });
         wasm.root_module.addCSourceFile(.{
             .file = b.path("src/wasm_open_url.cpp"),
+            .flags = imgui_backend_flags,
+        });
+        wasm.root_module.addCSourceFile(.{
+            .file = b.path("src/imgui_ini_bridge.cpp"),
             .flags = imgui_backend_flags,
         });
         const zgui_wasm_imgui = zgui_wasm_pkg.artifact("imgui");
@@ -413,6 +423,10 @@ pub fn build(b: *std.Build) void {
             android_lib.root_module.addCSourceFile(.{
                 .file = b.path("src/android_hid_stub.c"),
                 .flags = &.{},
+            });
+            android_lib.root_module.addCSourceFile(.{
+                .file = b.path("src/imgui_ini_bridge.cpp"),
+                .flags = &.{ "-std=c++17" },
             });
 
             const sdl_dep = b.dependency("SDL", .{

--- a/src/imgui_ini_bridge.cpp
+++ b/src/imgui_ini_bridge.cpp
@@ -1,0 +1,28 @@
+#include <stddef.h>
+#include "imgui.h"
+
+extern "C" {
+const char* zsc_imgui_save_ini_settings_to_memory(size_t* out_size) {
+    return ImGui::SaveIniSettingsToMemory(out_size);
+}
+
+void zsc_imgui_load_ini_settings_from_memory(const char* data, size_t size) {
+    ImGui::LoadIniSettingsFromMemory(data, size);
+}
+
+void zsc_imgui_set_next_window_dock_id(ImGuiID dock_id, ImGuiCond cond) {
+    ImGui::SetNextWindowDockID(dock_id, cond);
+}
+
+ImGuiID zsc_imgui_get_window_dock_id() {
+    return ImGui::GetWindowDockID();
+}
+
+bool zsc_imgui_get_want_save_ini_settings() {
+    return ImGui::GetIO().WantSaveIniSettings;
+}
+
+void zsc_imgui_clear_want_save_ini_settings() {
+    ImGui::GetIO().WantSaveIniSettings = false;
+}
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -25,12 +25,20 @@ pub const WebSocketClient = transport.WebSocketClient;
 
 pub const ui = struct {
     pub const imgui_wrapper = @import("ui/imgui_wrapper.zig");
+    pub const imgui_bridge = @import("ui/imgui_bridge.zig");
     pub const main_window = @import("ui/main_window.zig");
     pub const chat_view = @import("ui/chat_view.zig");
     pub const input_panel = @import("ui/input_panel.zig");
     pub const settings_view = @import("ui/settings_view.zig");
     pub const status_bar = @import("ui/status_bar.zig");
     pub const theme = @import("ui/theme.zig");
+    pub const text_buffer = @import("ui/text_buffer.zig");
+    pub const workspace = @import("ui/workspace.zig");
+    pub const panel_manager = @import("ui/panel_manager.zig");
+    pub const ui_command = @import("ui/ui_command.zig");
+    pub const ui_command_inbox = @import("ui/ui_command_inbox.zig");
+    pub const dock_layout = @import("ui/dock_layout.zig");
+    pub const workspace_store = @import("ui/workspace_store.zig");
 };
 
 pub const platform = struct {

--- a/src/ui/dock_layout.zig
+++ b/src/ui/dock_layout.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const zgui = @import("zgui");
+const workspace = @import("workspace.zig");
+const imgui_bridge = @import("imgui_bridge.zig");
+
+pub const DockState = struct {
+    dockspace_id: workspace.DockNodeId = 0,
+    left: workspace.DockNodeId = 0,
+    center: workspace.DockNodeId = 0,
+    right: workspace.DockNodeId = 0,
+    bottom: workspace.DockNodeId = 0,
+    initialized: bool = false,
+};
+
+pub fn ensureDockLayout(
+    state: *DockState,
+    workspace_state: *workspace.Workspace,
+    dockspace_id: workspace.DockNodeId,
+) void {
+    if (state.initialized) return;
+    state.initialized = true;
+    state.dockspace_id = dockspace_id;
+
+    if (workspace_state.layout.imgui_ini.len > 0) return;
+
+    const viewport = zgui.getMainViewport();
+    zgui.dockBuilderRemoveNode(dockspace_id);
+    _ = zgui.dockBuilderAddNode(dockspace_id, .{ .dock_space = true });
+    zgui.dockBuilderSetNodePos(dockspace_id, viewport.work_pos);
+    zgui.dockBuilderSetNodeSize(dockspace_id, viewport.work_size);
+
+    var left: zgui.Ident = 0;
+    var right: zgui.Ident = 0;
+    var bottom: zgui.Ident = 0;
+    var center: zgui.Ident = 0;
+    var middle: zgui.Ident = 0;
+
+    _ = zgui.dockBuilderSplitNode(dockspace_id, .left, 0.22, &left, &middle);
+    _ = zgui.dockBuilderSplitNode(middle, .right, 0.25, &right, &center);
+    _ = zgui.dockBuilderSplitNode(center, .down, 0.28, &bottom, &center);
+
+    state.left = left;
+    state.right = right;
+    state.bottom = bottom;
+    state.center = center;
+
+    zgui.dockBuilderFinish(dockspace_id);
+}
+
+pub fn defaultDockForKind(state: *DockState, kind: workspace.PanelKind) workspace.DockNodeId {
+    return switch (kind) {
+        .Chat => if (state.bottom != 0) state.bottom else state.dockspace_id,
+        .CodeEditor => if (state.center != 0) state.center else state.dockspace_id,
+        .ToolOutput => if (state.right != 0) state.right else state.dockspace_id,
+        .Control => if (state.left != 0) state.left else state.dockspace_id,
+    };
+}
+
+pub fn captureIni(allocator: std.mem.Allocator, workspace_state: *workspace.Workspace) !void {
+    const ini = try imgui_bridge.saveIniToMemory(allocator);
+    allocator.free(workspace_state.layout.imgui_ini);
+    workspace_state.layout.imgui_ini = ini;
+}

--- a/src/ui/imgui_bridge.zig
+++ b/src/ui/imgui_bridge.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const zgui = @import("zgui");
+
+extern fn zsc_imgui_save_ini_settings_to_memory(out_size: ?*usize) ?[*:0]const u8;
+extern fn zsc_imgui_load_ini_settings_from_memory(data: [*]const u8, size: usize) void;
+extern fn zsc_imgui_set_next_window_dock_id(dock_id: zgui.Ident, cond: zgui.Condition) void;
+extern fn zsc_imgui_get_window_dock_id() zgui.Ident;
+extern fn zsc_imgui_get_want_save_ini_settings() bool;
+extern fn zsc_imgui_clear_want_save_ini_settings() void;
+
+pub fn saveIniToMemory(allocator: std.mem.Allocator) ![]u8 {
+    var out_size: usize = 0;
+    const ptr = zsc_imgui_save_ini_settings_to_memory(&out_size) orelse return allocator.dupe(u8, "");
+    if (out_size == 0) return allocator.dupe(u8, "");
+    return allocator.dupe(u8, ptr[0..out_size]);
+}
+
+pub fn loadIniFromMemory(data: []const u8) void {
+    if (data.len == 0) return;
+    zsc_imgui_load_ini_settings_from_memory(data.ptr, data.len);
+}
+
+pub fn setNextWindowDockId(dock_id: zgui.Ident, cond: zgui.Condition) void {
+    zsc_imgui_set_next_window_dock_id(dock_id, cond);
+}
+
+pub fn getWindowDockId() zgui.Ident {
+    return zsc_imgui_get_window_dock_id();
+}
+
+pub fn wantSaveIniSettings() bool {
+    return zsc_imgui_get_want_save_ini_settings();
+}
+
+pub fn clearWantSaveIniSettings() void {
+    zsc_imgui_clear_want_save_ini_settings();
+}

--- a/src/ui/imgui_wrapper.zig
+++ b/src/ui/imgui_wrapper.zig
@@ -5,6 +5,8 @@ const theme = @import("theme.zig");
 
 pub fn init(allocator: std.mem.Allocator, window: *glfw.Window) void {
     zgui.init(allocator);
+    zgui.io.setConfigFlags(.{ .dock_enable = true });
+    zgui.io.setIniFilename(null);
     theme.apply();
     zgui.backend.init(window);
 }
@@ -15,6 +17,8 @@ pub fn initWithGlslVersion(
     glsl_version: [:0]const u8,
 ) void {
     zgui.init(allocator);
+    zgui.io.setConfigFlags(.{ .dock_enable = true });
+    zgui.io.setIniFilename(null);
     theme.apply();
     zgui.backend.initWithGlSlVersion(window, glsl_version);
 }

--- a/src/ui/imgui_wrapper_wgpu.zig
+++ b/src/ui/imgui_wrapper_wgpu.zig
@@ -11,6 +11,8 @@ pub fn init(
     depth_format: u32,
 ) void {
     zgui.init(allocator);
+    zgui.io.setConfigFlags(.{ .dock_enable = true });
+    zgui.io.setIniFilename(null);
     theme.apply();
     zgui.backend.init(
         @ptrCast(window),

--- a/src/ui/main_window.zig
+++ b/src/ui/main_window.zig
@@ -3,14 +3,15 @@ const zgui = @import("zgui");
 const builtin = @import("builtin");
 const state = @import("../client/state.zig");
 const config = @import("../client/config.zig");
-const layout = @import("layout.zig");
-const ui_state = @import("state.zig");
 const theme = @import("theme.zig");
-const sessions_panel = @import("panels/sessions_panel.zig");
+const panel_manager = @import("panel_manager.zig");
+const dock_layout = @import("dock_layout.zig");
+const ui_command_inbox = @import("ui_command_inbox.zig");
+const imgui_bridge = @import("imgui_bridge.zig");
 const chat_panel = @import("panels/chat_panel.zig");
-const settings_panel = @import("panels/settings_panel.zig");
-const settings_view = @import("settings_view.zig");
-const operator_view = @import("operator_view.zig");
+const code_editor_panel = @import("panels/code_editor_panel.zig");
+const tool_output_panel = @import("panels/tool_output_panel.zig");
+const control_panel = @import("panels/control_panel.zig");
 const status_bar = @import("status_bar.zig");
 
 pub const UiAction = struct {
@@ -29,12 +30,13 @@ pub const UiAction = struct {
     install_update: bool = false,
     refresh_nodes: bool = false,
     select_node: ?[]u8 = null,
-    invoke_node: ?operator_view.NodeInvokeAction = null,
+    invoke_node: ?@import("operator_view.zig").NodeInvokeAction = null,
     describe_node: ?[]u8 = null,
-    resolve_approval: ?operator_view.ExecApprovalResolveAction = null,
+    resolve_approval: ?@import("operator_view.zig").ExecApprovalResolveAction = null,
     clear_node_describe: ?[]u8 = null,
     clear_node_result: bool = false,
     clear_operator_notice: bool = false,
+    save_workspace: bool = false,
 };
 
 var safe_insets: [4]f32 = .{ 0.0, 0.0, 0.0, 0.0 };
@@ -49,9 +51,13 @@ pub fn draw(
     cfg: *config.Config,
     is_connected: bool,
     app_version: []const u8,
-    state_ui: *ui_state.UiState,
+    manager: *panel_manager.PanelManager,
+    inbox: *ui_command_inbox.UiCommandInbox,
+    dock_state: *dock_layout.DockState,
 ) UiAction {
     var action = UiAction{};
+
+    inbox.collectFromMessages(allocator, ctx.messages.items, manager);
 
     const display = zgui.io.getDisplaySize();
     if (display[0] > 0.0 and display[1] > 0.0) {
@@ -66,229 +72,139 @@ pub fn draw(
         zgui.setNextWindowSize(.{ .w = width, .h = height, .cond = .always });
     }
 
-    const compact_header = builtin.abi == .android or (display[1] > 0.0 and display[1] < 720.0);
-    var flags = zgui.WindowFlags{ .no_collapse = true, .no_saved_settings = true };
-    if (compact_header) {
-        flags.no_title_bar = true;
-        flags.no_scrollbar = true;
-        flags.no_scroll_with_mouse = true;
-    }
+    const host_flags = zgui.WindowFlags{
+        .no_title_bar = true,
+        .no_resize = true,
+        .no_move = true,
+        .no_collapse = true,
+        .no_bring_to_front_on_focus = true,
+        .no_saved_settings = true,
+        .no_nav_focus = true,
+        .no_background = true,
+    };
 
-    if (zgui.begin("ZiggyStarClaw", .{ .flags = flags })) {
-        if (!compact_header) {
-            theme.push(.title);
-            zgui.text("ZiggyStarClaw and the Lobsters From Mars", .{});
-            theme.pop();
-            zgui.separator();
-        }
+    if (zgui.begin("WorkspaceHost", .{ .flags = host_flags })) {
+        const dockspace_id = zgui.dockSpace("MainDockSpace", .{ 0.0, 0.0 }, .{ .passthru_central_node = true });
+        dock_layout.ensureDockLayout(dock_state, &manager.workspace, dockspace_id);
 
-        const style = zgui.getStyle();
-        const spacing_x = style.item_spacing[0];
-        const spacing_y = style.item_spacing[1];
-        const avail = zgui.getContentRegionAvail();
-        const status_height = zgui.getFrameHeightWithSpacing();
-        const usable_h = @max(1.0, avail[1] - status_height - spacing_y);
-
-        var metrics = layout.compute(state_ui, avail[0], usable_h, spacing_x, spacing_y);
-
-        if (metrics.compact_layout) {
-            if (zgui.beginChild(
-                "SessionsPanel",
-                .{ .w = metrics.avail_width, .h = metrics.sessions_height, .child_flags = .{ .border = true } },
-            )) {
-                const sessions_action = sessions_panel.draw(allocator, ctx);
-                action.refresh_sessions = sessions_action.refresh;
-                action.select_session = sessions_action.selected_key;
+        var index: usize = 0;
+        while (index < manager.workspace.panels.items.len) {
+            var panel = &manager.workspace.panels.items[index];
+            if (panel.state.dock_node == 0 and dock_state.dockspace_id != 0) {
+                imgui_bridge.setNextWindowDockId(
+                    dock_layout.defaultDockForKind(dock_state, panel.kind),
+                    .first_use_ever,
+                );
             }
-            zgui.endChild();
-
-            if (layout.splitterHorizontal(
-                "split_sessions",
-                metrics.avail_width,
-                metrics.splitter,
-                &state_ui.compact_sessions_height,
-                state_ui.min_sessions_height,
-                metrics.usable_height,
-                1.0,
-            )) {
-                metrics = layout.compute(state_ui, avail[0], usable_h, spacing_x, spacing_y);
+            if (manager.workspace.focused_panel_id != null and
+                manager.workspace.focused_panel_id.? == panel.id)
+            {
+                zgui.setNextWindowFocus();
             }
 
-            if (zgui.beginChild(
-                "ChatPanel",
-                .{ .w = metrics.avail_width, .h = metrics.chat_height, .child_flags = .{ .border = true } },
-            )) {
-                const chat_action = chat_panel.draw(allocator, ctx);
-                action.send_message = chat_action.send_message;
-            }
-            zgui.endChild();
-
-            if (layout.splitterHorizontal(
-                "split_settings",
-                metrics.avail_width,
-                metrics.splitter,
-                &state_ui.compact_settings_height,
-                state_ui.min_settings_height,
-                metrics.usable_height,
-                -1.0,
-            )) {
-                metrics = layout.compute(state_ui, avail[0], usable_h, spacing_x, spacing_y);
-            }
-
-            if (zgui.beginChild(
-                "RightPanel",
-                .{ .w = metrics.avail_width, .h = metrics.settings_height, .child_flags = .{ .border = true } },
-            )) {
-                if (zgui.beginTabBar("RightTabs", .{})) {
-                    if (zgui.beginTabItem("Settings", .{})) {
-                        const settings_action = settings_panel.draw(
+            var open = true;
+            const label = zgui.formatZ("{s}##panel_{d}", .{ panel.title, panel.id });
+            if (zgui.begin(label, .{ .popen = &open, .flags = .{ .no_saved_settings = true } })) {
+                switch (panel.kind) {
+                    .Chat => {
+                        const chat_action = chat_panel.draw(allocator, ctx, inbox);
+                        action.send_message = chat_action.send_message;
+                    },
+                    .CodeEditor => {
+                        if (code_editor_panel.draw(panel, allocator)) {
+                            manager.workspace.markDirty();
+                        }
+                    },
+                    .ToolOutput => {
+                        tool_output_panel.draw(panel, allocator);
+                    },
+                    .Control => {
+                        const control_action = control_panel.draw(
                             allocator,
+                            ctx,
                             cfg,
-                            ctx.state,
                             is_connected,
-                            &ctx.update_state,
                             app_version,
+                            &panel.data.Control,
                         );
-                        action.connect = settings_action.connect;
-                        action.disconnect = settings_action.disconnect;
-                        action.save_config = settings_action.save;
-                        action.clear_saved = settings_action.clear_saved;
-                        action.config_updated = settings_action.config_updated;
-                        action.check_updates = settings_action.check_updates;
-                        action.open_release = settings_action.open_release;
-                        action.download_update = settings_action.download_update;
-                        action.open_download = settings_action.open_download;
-                        action.install_update = settings_action.install_update;
-                        zgui.endTabItem();
-                    }
-                    if (zgui.beginTabItem("Operator", .{})) {
-                        const operator_action = operator_view.draw(allocator, ctx, is_connected);
-                        action.refresh_nodes = operator_action.refresh_nodes;
-                        action.select_node = operator_action.select_node;
-                        action.invoke_node = operator_action.invoke_node;
-                        action.describe_node = operator_action.describe_node;
-                        action.resolve_approval = operator_action.resolve_approval;
-                        action.clear_node_describe = operator_action.clear_node_describe;
-                        action.clear_node_result = operator_action.clear_node_result;
-                        action.clear_operator_notice = operator_action.clear_operator_notice;
-                        zgui.endTabItem();
-                    }
-                    zgui.endTabBar();
+                        action.connect = control_action.connect;
+                        action.disconnect = control_action.disconnect;
+                        action.save_config = control_action.save_config;
+                        action.clear_saved = control_action.clear_saved;
+                        action.config_updated = control_action.config_updated;
+                        action.refresh_sessions = control_action.refresh_sessions;
+                        action.select_session = control_action.select_session;
+                        action.check_updates = control_action.check_updates;
+                        action.open_release = control_action.open_release;
+                        action.download_update = control_action.download_update;
+                        action.open_download = control_action.open_download;
+                        action.install_update = control_action.install_update;
+                        action.refresh_nodes = control_action.refresh_nodes;
+                        action.select_node = control_action.select_node;
+                        action.invoke_node = control_action.invoke_node;
+                        action.describe_node = control_action.describe_node;
+                        action.resolve_approval = control_action.resolve_approval;
+                        action.clear_node_describe = control_action.clear_node_describe;
+                        action.clear_node_result = control_action.clear_node_result;
+                        action.clear_operator_notice = control_action.clear_operator_notice;
+                    },
                 }
             }
-            zgui.endChild();
-        } else {
-            if (zgui.beginChild(
-                "SessionsPanel",
-                .{ .w = metrics.left_width, .h = metrics.usable_height, .child_flags = .{ .border = true } },
-            )) {
-                const sessions_action = sessions_panel.draw(allocator, ctx);
-                action.refresh_sessions = sessions_action.refresh;
-                action.select_session = sessions_action.selected_key;
+
+            const dock_id = imgui_bridge.getWindowDockId();
+            if (dock_id != 0 and dock_id != panel.state.dock_node) {
+                panel.state.dock_node = dock_id;
+                manager.workspace.markDirty();
+            } else {
+                panel.state.dock_node = dock_id;
             }
-            zgui.endChild();
-
-            zgui.sameLine(.{ .spacing = spacing_x });
-
-            const total_gap = state_ui.splitter_thickness * 2.0 + spacing_x * 2.0;
-            const max_left = @max(
-                state_ui.min_left_width,
-                avail[0] - state_ui.right_width - state_ui.min_center_width - total_gap,
-            );
-            if (layout.splitterVertical(
-                "split_left",
-                metrics.usable_height,
-                metrics.splitter,
-                &state_ui.left_width,
-                state_ui.min_left_width,
-                max_left,
-                1.0,
-            )) {
-                metrics = layout.compute(state_ui, avail[0], usable_h, spacing_x, spacing_y);
-            }
-
-            zgui.sameLine(.{ .spacing = spacing_x });
-
-            if (zgui.beginChild(
-                "ChatPanel",
-                .{ .w = metrics.center_width, .h = metrics.usable_height, .child_flags = .{ .border = true } },
-            )) {
-                const chat_action = chat_panel.draw(allocator, ctx);
-                action.send_message = chat_action.send_message;
-            }
-            zgui.endChild();
-
-            zgui.sameLine(.{ .spacing = spacing_x });
-
-            const max_right = @max(
-                state_ui.min_right_width,
-                avail[0] - state_ui.left_width - state_ui.min_center_width - total_gap,
-            );
-            if (layout.splitterVertical(
-                "split_right",
-                metrics.usable_height,
-                metrics.splitter,
-                &state_ui.right_width,
-                state_ui.min_right_width,
-                max_right,
-                -1.0,
-            )) {
-                metrics = layout.compute(state_ui, avail[0], usable_h, spacing_x, spacing_y);
-            }
-
-            zgui.sameLine(.{ .spacing = spacing_x });
-
-            if (zgui.beginChild(
-                "RightPanel",
-                .{ .w = metrics.right_width, .h = metrics.usable_height, .child_flags = .{ .border = true } },
-            )) {
-                if (zgui.beginTabBar("RightTabs", .{})) {
-                    if (zgui.beginTabItem("Settings", .{})) {
-                        const settings_action = settings_panel.draw(
-                            allocator,
-                            cfg,
-                            ctx.state,
-                            is_connected,
-                            &ctx.update_state,
-                            app_version,
-                        );
-                        action.connect = settings_action.connect;
-                        action.disconnect = settings_action.disconnect;
-                        action.save_config = settings_action.save;
-                        action.clear_saved = settings_action.clear_saved;
-                        action.config_updated = settings_action.config_updated;
-                        action.check_updates = settings_action.check_updates;
-                        action.open_release = settings_action.open_release;
-                        action.download_update = settings_action.download_update;
-                        action.open_download = settings_action.open_download;
-                        action.install_update = settings_action.install_update;
-                        zgui.endTabItem();
-                    }
-                    if (zgui.beginTabItem("Operator", .{})) {
-                        const operator_action = operator_view.draw(allocator, ctx, is_connected);
-                        action.refresh_nodes = operator_action.refresh_nodes;
-                        action.select_node = operator_action.select_node;
-                        action.invoke_node = operator_action.invoke_node;
-                        action.describe_node = operator_action.describe_node;
-                        action.resolve_approval = operator_action.resolve_approval;
-                        action.clear_node_describe = operator_action.clear_node_describe;
-                        action.clear_node_result = operator_action.clear_node_result;
-                        action.clear_operator_notice = operator_action.clear_operator_notice;
-                        zgui.endTabItem();
-                    }
-                    zgui.endTabBar();
+            panel.state.is_focused = zgui.isWindowFocused(zgui.FocusedFlags.root_and_child_windows);
+            if (panel.state.is_focused) {
+                if (manager.workspace.focused_panel_id == null or manager.workspace.focused_panel_id.? != panel.id) {
+                    manager.workspace.focused_panel_id = panel.id;
+                    manager.workspace.markDirty();
                 }
             }
-            zgui.endChild();
-        }
 
-        status_bar.draw(ctx.state, is_connected, ctx.current_session, ctx.messages.items.len, ctx.last_error);
+            zgui.end();
+
+            if (!open) {
+                _ = manager.closePanel(panel.id);
+                continue;
+            }
+
+            index += 1;
+        }
     }
     zgui.end();
+
+    const viewport = zgui.getMainViewport();
+    const status_height = zgui.getFrameHeightWithSpacing();
+    zgui.setNextWindowPos(.{ .x = viewport.work_pos[0], .y = viewport.work_pos[1] + viewport.work_size[1] - status_height, .cond = .always });
+    zgui.setNextWindowSize(.{ .w = viewport.work_size[0], .h = status_height, .cond = .always });
+    const status_flags = zgui.WindowFlags{
+        .no_title_bar = true,
+        .no_resize = true,
+        .no_move = true,
+        .no_saved_settings = true,
+        .no_docking = true,
+    };
+    if (zgui.begin("StatusBar##overlay", .{ .flags = status_flags })) {
+        theme.push(.body);
+        status_bar.draw(ctx.state, is_connected, ctx.current_session, ctx.messages.items.len, ctx.last_error);
+        theme.pop();
+    }
+    zgui.end();
+
+    if (imgui_bridge.wantSaveIniSettings()) {
+        action.save_workspace = true;
+        imgui_bridge.clearWantSaveIniSettings();
+    }
+    if (manager.workspace.dirty) action.save_workspace = true;
 
     return action;
 }
 
 pub fn syncSettings(cfg: config.Config) void {
-    settings_view.syncFromConfig(cfg);
+    @import("settings_view.zig").syncFromConfig(cfg);
 }

--- a/src/ui/panel_manager.zig
+++ b/src/ui/panel_manager.zig
@@ -1,0 +1,294 @@
+const std = @import("std");
+const workspace = @import("workspace.zig");
+const ui_command = @import("ui_command.zig");
+const text_buffer = @import("text_buffer.zig");
+
+pub const PanelManager = struct {
+    allocator: std.mem.Allocator,
+    workspace: workspace.Workspace,
+    next_panel_id: workspace.PanelId,
+
+    pub fn init(allocator: std.mem.Allocator, ws: workspace.Workspace) PanelManager {
+        var manager = PanelManager{
+            .allocator = allocator,
+            .workspace = ws,
+            .next_panel_id = 1,
+        };
+        manager.recomputeNextId();
+        return manager;
+    }
+
+    pub fn deinit(self: *PanelManager) void {
+        self.workspace.deinit(self.allocator);
+    }
+
+    pub fn recomputeNextId(self: *PanelManager) void {
+        var max_id: workspace.PanelId = 0;
+        for (self.workspace.panels.items) |panel| {
+            if (panel.id > max_id) max_id = panel.id;
+        }
+        self.next_panel_id = max_id + 1;
+    }
+
+    pub fn applyUiCommand(self: *PanelManager, cmd: ui_command.UiCommand) !void {
+        switch (cmd) {
+            .OpenPanel => |open| try self.applyOpen(open),
+            .UpdatePanel => |update| _ = try self.applyUpdate(update),
+            .FocusPanel => |panel_id| self.focusPanel(panel_id),
+            .ClosePanel => |panel_id| _ = self.closePanel(panel_id),
+        }
+    }
+
+    pub fn openPanel(
+        self: *PanelManager,
+        kind: workspace.PanelKind,
+        title: []const u8,
+        data: workspace.PanelData,
+    ) !workspace.PanelId {
+        const id = self.next_panel_id;
+        self.next_panel_id += 1;
+        const title_copy = try self.allocator.dupe(u8, title);
+        try self.workspace.panels.append(self.allocator, .{
+            .id = id,
+            .kind = kind,
+            .title = title_copy,
+            .data = data,
+            .state = .{},
+        });
+        self.workspace.markDirty();
+        return id;
+    }
+
+    pub fn updatePanel(
+        self: *PanelManager,
+        id: workspace.PanelId,
+        data: workspace.PanelData,
+        title: ?[]const u8,
+    ) bool {
+        for (self.workspace.panels.items) |*panel| {
+            if (panel.id == id) {
+                if (title) |new_title| {
+                    self.allocator.free(panel.title);
+                    panel.title = self.allocator.dupe(u8, new_title) catch panel.title;
+                }
+                panel.data.deinit(self.allocator);
+                panel.data = data;
+                self.workspace.markDirty();
+                return true;
+            }
+        }
+        data.deinit(self.allocator);
+        return false;
+    }
+
+    pub fn focusPanel(self: *PanelManager, id: workspace.PanelId) void {
+        self.workspace.focused_panel_id = id;
+        self.workspace.markDirty();
+    }
+
+    pub fn closePanel(self: *PanelManager, id: workspace.PanelId) bool {
+        var index: usize = 0;
+        while (index < self.workspace.panels.items.len) : (index += 1) {
+            if (self.workspace.panels.items[index].id == id) {
+                var removed = self.workspace.panels.orderedRemove(index);
+                removed.deinit(self.allocator);
+                self.workspace.markDirty();
+                if (self.workspace.focused_panel_id != null and self.workspace.focused_panel_id.? == id) {
+                    self.workspace.focused_panel_id = null;
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    pub fn findReusablePanel(
+        self: *PanelManager,
+        kind: workspace.PanelKind,
+        key: ?[]const u8,
+    ) ?*workspace.Panel {
+        switch (kind) {
+            .Chat => {
+                if (key) |session| {
+                    for (self.workspace.panels.items) |*panel| {
+                        if (panel.kind != .Chat) continue;
+                        const data = panel.data.Chat;
+                        if (data.session_key) |existing| {
+                            if (std.mem.eql(u8, existing, session)) return panel;
+                        }
+                    }
+                }
+                for (self.workspace.panels.items) |*panel| {
+                    if (panel.kind == .Chat) return panel;
+                }
+            },
+            .CodeEditor => {
+                if (key) |file_id| {
+                    for (self.workspace.panels.items) |*panel| {
+                        if (panel.kind != .CodeEditor) continue;
+                        if (std.mem.eql(u8, panel.data.CodeEditor.file_id, file_id)) return panel;
+                    }
+                }
+            },
+            .Control => {
+                for (self.workspace.panels.items) |*panel| {
+                    if (panel.kind == .Control) return panel;
+                }
+            },
+            .ToolOutput => {},
+        }
+        return null;
+    }
+
+    fn applyOpen(self: *PanelManager, open: ui_command.OpenPanelCmd) !void {
+        const payload = open.data;
+        switch (open.kind) {
+            .Chat => {
+                const session = if (payload) |data| data.Chat.session else null;
+                if (self.findReusablePanel(.Chat, session)) |panel| {
+                    if (session) |key| {
+                        if (panel.data.Chat.session_key) |prev| self.allocator.free(prev);
+                        panel.data.Chat.session_key = try self.allocator.dupe(u8, key);
+                    }
+                    self.focusPanel(panel.id);
+                    return;
+                }
+                const session_copy = if (session) |key| try self.allocator.dupe(u8, key) else null;
+                const data = workspace.PanelData{ .Chat = .{ .session_key = session_copy } };
+                _ = try self.openPanel(.Chat, open.title orelse "Chat", data);
+            },
+            .CodeEditor => {
+                if (payload == null) return;
+                const data = payload.?.CodeEditor;
+                const file_id = data.file orelse return;
+
+                if (self.findReusablePanel(.CodeEditor, file_id)) |panel| {
+                    if (data.content) |content| {
+                        try panel.data.CodeEditor.content.set(self.allocator, content);
+                        panel.data.CodeEditor.last_modified_by = .ai;
+                        panel.data.CodeEditor.version += 1;
+                        panel.state.is_dirty = false;
+                    }
+                    if (data.language) |language| {
+                        self.allocator.free(panel.data.CodeEditor.language);
+                        panel.data.CodeEditor.language = try self.allocator.dupe(u8, language);
+                    }
+                    self.focusPanel(panel.id);
+                    return;
+                }
+
+                const language = data.language orelse "text";
+                const content = data.content orelse "";
+                const file_copy = try self.allocator.dupe(u8, file_id);
+                const lang_copy = try self.allocator.dupe(u8, language);
+                const buffer = try text_buffer.TextBuffer.init(self.allocator, content);
+                const panel_data = workspace.PanelData{ .CodeEditor = .{
+                    .file_id = file_copy,
+                    .language = lang_copy,
+                    .content = buffer,
+                    .last_modified_by = .ai,
+                    .version = 1,
+                } };
+                _ = try self.openPanel(.CodeEditor, open.title orelse file_id, panel_data);
+            },
+            .ToolOutput => {
+                if (payload == null) return;
+                const data = payload.?.ToolOutput;
+                const tool_name = data.tool_name orelse return;
+                const stdout = data.stdout orelse "";
+                const stderr = data.stderr orelse "";
+                const exit_code = data.exit_code orelse 0;
+                const tool_copy = try self.allocator.dupe(u8, tool_name);
+                const stdout_buf = try text_buffer.TextBuffer.init(self.allocator, stdout);
+                const stderr_buf = try text_buffer.TextBuffer.init(self.allocator, stderr);
+                const panel_data = workspace.PanelData{ .ToolOutput = .{
+                    .tool_name = tool_copy,
+                    .stdout = stdout_buf,
+                    .stderr = stderr_buf,
+                    .exit_code = exit_code,
+                } };
+                _ = try self.openPanel(.ToolOutput, open.title orelse "Tool Output", panel_data);
+            },
+            .Control => {
+                if (self.findReusablePanel(.Control, null)) |panel| {
+                    if (payload) |data| {
+                        if (data.Control.active_tab) |tab| {
+                            panel.data.Control.active_tab = parseControlTab(tab);
+                        }
+                    }
+                    self.focusPanel(panel.id);
+                    return;
+                }
+                const panel_data = workspace.PanelData{ .Control = .{} };
+                _ = try self.openPanel(.Control, open.title orelse "Control", panel_data);
+            },
+        }
+    }
+
+    fn applyUpdate(self: *PanelManager, update: ui_command.UpdatePanelCmd) !bool {
+        for (self.workspace.panels.items) |*panel| {
+            if (panel.id != update.id) continue;
+            if (update.title) |title| {
+                self.allocator.free(panel.title);
+                panel.title = try self.allocator.dupe(u8, title);
+            }
+            switch (update.data) {
+                .Chat => |data| {
+                    if (panel.kind != .Chat) return false;
+                    if (data.session) |session| {
+                        if (panel.data.Chat.session_key) |prev| self.allocator.free(prev);
+                        panel.data.Chat.session_key = try self.allocator.dupe(u8, session);
+                    }
+                },
+                .CodeEditor => |data| {
+                    if (panel.kind != .CodeEditor) return false;
+                    if (data.file) |file| {
+                        self.allocator.free(panel.data.CodeEditor.file_id);
+                        panel.data.CodeEditor.file_id = try self.allocator.dupe(u8, file);
+                    }
+                    if (data.language) |language| {
+                        self.allocator.free(panel.data.CodeEditor.language);
+                        panel.data.CodeEditor.language = try self.allocator.dupe(u8, language);
+                    }
+                    if (data.content) |content| {
+                        try panel.data.CodeEditor.content.set(self.allocator, content);
+                        panel.data.CodeEditor.last_modified_by = .ai;
+                        panel.data.CodeEditor.version += 1;
+                        panel.state.is_dirty = false;
+                    }
+                },
+                .ToolOutput => |data| {
+                    if (panel.kind != .ToolOutput) return false;
+                    if (data.tool_name) |name| {
+                        self.allocator.free(panel.data.ToolOutput.tool_name);
+                        panel.data.ToolOutput.tool_name = try self.allocator.dupe(u8, name);
+                    }
+                    if (data.stdout) |stdout| {
+                        try panel.data.ToolOutput.stdout.set(self.allocator, stdout);
+                    }
+                    if (data.stderr) |stderr| {
+                        try panel.data.ToolOutput.stderr.set(self.allocator, stderr);
+                    }
+                    if (data.exit_code) |code| {
+                        panel.data.ToolOutput.exit_code = code;
+                    }
+                },
+                .Control => |data| {
+                    if (panel.kind != .Control) return false;
+                    if (data.active_tab) |tab| {
+                        panel.data.Control.active_tab = parseControlTab(tab);
+                    }
+                },
+            }
+            self.workspace.markDirty();
+            return true;
+        }
+        return false;
+    }
+};
+
+fn parseControlTab(label: []const u8) workspace.ControlTab {
+    if (std.mem.eql(u8, label, "Settings")) return .Settings;
+    if (std.mem.eql(u8, label, "Operator")) return .Operator;
+    return .Sessions;
+}

--- a/src/ui/panels/chat_panel.zig
+++ b/src/ui/panels/chat_panel.zig
@@ -3,6 +3,7 @@ const zgui = @import("zgui");
 const state = @import("../../client/state.zig");
 const chat_view = @import("../chat_view.zig");
 const input_panel = @import("../input_panel.zig");
+const ui_command_inbox = @import("../ui_command_inbox.zig");
 
 pub const ChatPanelAction = struct {
     send_message: ?[]u8 = null,
@@ -11,12 +12,13 @@ pub const ChatPanelAction = struct {
 pub fn draw(
     allocator: std.mem.Allocator,
     ctx: *state.ClientContext,
+    inbox: ?*const ui_command_inbox.UiCommandInbox,
 ) ChatPanelAction {
     var action = ChatPanelAction{};
     const center_avail = zgui.getContentRegionAvail();
     const input_height: f32 = 88.0;
     const history_height = @max(80.0, center_avail[1] - input_height - zgui.getStyle().item_spacing[1]);
-    chat_view.draw(allocator, ctx.messages.items, ctx.stream_text, history_height);
+    chat_view.draw(allocator, ctx.messages.items, ctx.stream_text, inbox, history_height);
     zgui.separator();
     if (input_panel.draw(allocator)) |message| {
         action.send_message = message;

--- a/src/ui/panels/code_editor_panel.zig
+++ b/src/ui/panels/code_editor_panel.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+const zgui = @import("zgui");
+const workspace = @import("../workspace.zig");
+
+pub fn draw(panel: *workspace.Panel, allocator: std.mem.Allocator) bool {
+    if (panel.kind != .CodeEditor) return false;
+    var editor = &panel.data.CodeEditor;
+
+    zgui.text("File:", .{});
+    zgui.sameLine(.{});
+    zgui.text("{s}", .{editor.file_id});
+    zgui.sameLine(.{ .spacing = 12.0 });
+    zgui.textDisabled("({s})", .{editor.language});
+    zgui.separator();
+
+    const avail = zgui.getContentRegionAvail();
+    const min_capacity = @max(@as(usize, 64 * 1024), editor.content.slice().len);
+    _ = editor.content.ensureCapacity(allocator, min_capacity) catch {};
+
+    const changed = zgui.inputTextMultiline("##code_editor", .{
+        .buf = editor.content.asZ(),
+        .h = avail[1] - zgui.getFrameHeightWithSpacing(),
+        .flags = .{ .allow_tab_input = true },
+    });
+
+    if (changed) {
+        editor.content.syncFromInput();
+        editor.last_modified_by = .user;
+        editor.version += 1;
+        panel.state.is_dirty = true;
+    }
+
+    zgui.separator();
+    zgui.textDisabled("v{d} · {s}", .{
+        editor.version,
+        if (editor.last_modified_by == .user) "edited" else "ai",
+    });
+    return changed;
+}

--- a/src/ui/panels/control_panel.zig
+++ b/src/ui/panels/control_panel.zig
@@ -1,0 +1,90 @@
+const std = @import("std");
+const zgui = @import("zgui");
+const state = @import("../../client/state.zig");
+const config = @import("../../client/config.zig");
+const sessions_panel = @import("sessions_panel.zig");
+const settings_panel = @import("settings_panel.zig");
+const operator_view = @import("../operator_view.zig");
+const workspace = @import("../workspace.zig");
+
+pub const ControlPanelAction = struct {
+    connect: bool = false,
+    disconnect: bool = false,
+    save_config: bool = false,
+    clear_saved: bool = false,
+    config_updated: bool = false,
+    refresh_sessions: bool = false,
+    select_session: ?[]u8 = null,
+    check_updates: bool = false,
+    open_release: bool = false,
+    download_update: bool = false,
+    open_download: bool = false,
+    install_update: bool = false,
+    refresh_nodes: bool = false,
+    select_node: ?[]u8 = null,
+    invoke_node: ?operator_view.NodeInvokeAction = null,
+    describe_node: ?[]u8 = null,
+    resolve_approval: ?operator_view.ExecApprovalResolveAction = null,
+    clear_node_describe: ?[]u8 = null,
+    clear_node_result: bool = false,
+    clear_operator_notice: bool = false,
+};
+
+pub fn draw(
+    allocator: std.mem.Allocator,
+    ctx: *state.ClientContext,
+    cfg: *config.Config,
+    is_connected: bool,
+    app_version: []const u8,
+    panel: *workspace.ControlPanel,
+) ControlPanelAction {
+    var action = ControlPanelAction{};
+
+    if (zgui.beginTabBar("ControlTabs", .{})) {
+        if (zgui.beginTabItem("Sessions", .{})) {
+            panel.active_tab = .Sessions;
+            const sessions_action = sessions_panel.draw(allocator, ctx);
+            action.refresh_sessions = sessions_action.refresh;
+            action.select_session = sessions_action.selected_key;
+            zgui.endTabItem();
+        }
+        if (zgui.beginTabItem("Settings", .{})) {
+            panel.active_tab = .Settings;
+            const settings_action = settings_panel.draw(
+                allocator,
+                cfg,
+                ctx.state,
+                is_connected,
+                &ctx.update_state,
+                app_version,
+            );
+            action.connect = settings_action.connect;
+            action.disconnect = settings_action.disconnect;
+            action.save_config = settings_action.save;
+            action.clear_saved = settings_action.clear_saved;
+            action.config_updated = settings_action.config_updated;
+            action.check_updates = settings_action.check_updates;
+            action.open_release = settings_action.open_release;
+            action.download_update = settings_action.download_update;
+            action.open_download = settings_action.open_download;
+            action.install_update = settings_action.install_update;
+            zgui.endTabItem();
+        }
+        if (zgui.beginTabItem("Operator", .{})) {
+            panel.active_tab = .Operator;
+            const operator_action = operator_view.draw(allocator, ctx, is_connected);
+            action.refresh_nodes = operator_action.refresh_nodes;
+            action.select_node = operator_action.select_node;
+            action.invoke_node = operator_action.invoke_node;
+            action.describe_node = operator_action.describe_node;
+            action.resolve_approval = operator_action.resolve_approval;
+            action.clear_node_describe = operator_action.clear_node_describe;
+            action.clear_node_result = operator_action.clear_node_result;
+            action.clear_operator_notice = operator_action.clear_operator_notice;
+            zgui.endTabItem();
+        }
+        zgui.endTabBar();
+    }
+
+    return action;
+}

--- a/src/ui/panels/tool_output_panel.zig
+++ b/src/ui/panels/tool_output_panel.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+const zgui = @import("zgui");
+const workspace = @import("../workspace.zig");
+
+pub fn draw(panel: *workspace.Panel, allocator: std.mem.Allocator) void {
+    if (panel.kind != .ToolOutput) return;
+    _ = allocator;
+    const output = &panel.data.ToolOutput;
+
+    zgui.text("Tool:", .{});
+    zgui.sameLine(.{});
+    zgui.text("{s}", .{output.tool_name});
+    zgui.sameLine(.{ .spacing = 12.0 });
+    zgui.textDisabled("exit {d}", .{output.exit_code});
+    zgui.separator();
+
+    zgui.textDisabled("stdout", .{});
+    _ = zgui.inputTextMultiline("##tool_stdout", .{
+        .buf = output.stdout.asZ(),
+        .h = 140.0,
+        .flags = .{ .read_only = true },
+    });
+    zgui.separator();
+    zgui.textDisabled("stderr", .{});
+    _ = zgui.inputTextMultiline("##tool_stderr", .{
+        .buf = output.stderr.asZ(),
+        .h = 140.0,
+        .flags = .{ .read_only = true },
+    });
+}

--- a/src/ui/text_buffer.zig
+++ b/src/ui/text_buffer.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+
+pub const TextBuffer = struct {
+    data: std.ArrayList(u8),
+
+    pub fn init(allocator: std.mem.Allocator, text: []const u8) !TextBuffer {
+        var list = std.ArrayList(u8).empty;
+        try list.ensureTotalCapacity(allocator, text.len + 1);
+        list.appendSliceAssumeCapacity(text);
+        list.appendAssumeCapacity(0);
+        return .{ .data = list };
+    }
+
+    pub fn deinit(self: *TextBuffer, allocator: std.mem.Allocator) void {
+        self.data.deinit(allocator);
+    }
+
+    pub fn set(self: *TextBuffer, allocator: std.mem.Allocator, text: []const u8) !void {
+        self.data.clearRetainingCapacity();
+        try self.data.ensureTotalCapacity(allocator, text.len + 1);
+        self.data.appendSliceAssumeCapacity(text);
+        self.data.appendAssumeCapacity(0);
+    }
+
+    pub fn ensureCapacity(self: *TextBuffer, allocator: std.mem.Allocator, min_len: usize) !void {
+        const desired = min_len + 1;
+        if (self.data.items.len < desired) {
+            try self.data.ensureTotalCapacity(allocator, desired);
+            const extra = desired - self.data.items.len;
+            if (extra > 0) {
+                try self.data.appendNTimes(allocator, 0, extra);
+            }
+        }
+    }
+
+    pub fn syncFromInput(self: *TextBuffer) void {
+        const len = std.mem.indexOfScalar(u8, self.data.items, 0) orelse self.data.items.len;
+        if (len < self.data.items.len) {
+            self.data.items.len = len + 1;
+            return;
+        }
+        if (self.data.capacity > self.data.items.len) {
+            self.data.appendAssumeCapacity(0);
+        }
+    }
+
+    pub fn asZ(self: *TextBuffer) [:0]u8 {
+        if (self.data.items.len == 0) return @constCast(empty_z[0.. :0]);
+        if (self.data.items.len == 1) return @constCast(empty_z[0.. :0]);
+        const end = self.data.items.len - 1;
+        return self.data.items[0..end :0];
+    }
+
+    pub fn slice(self: *const TextBuffer) []const u8 {
+        if (self.data.items.len == 0) return "";
+        if (self.data.items.len == 1) return "";
+        return self.data.items[0 .. self.data.items.len - 1];
+    }
+
+    const empty_z = [_:0]u8{};
+};

--- a/src/ui/ui_command.zig
+++ b/src/ui/ui_command.zig
@@ -1,0 +1,318 @@
+const std = @import("std");
+const workspace = @import("workspace.zig");
+
+pub const UiCommand = union(enum) {
+    OpenPanel: OpenPanelCmd,
+    UpdatePanel: UpdatePanelCmd,
+    FocusPanel: workspace.PanelId,
+    ClosePanel: workspace.PanelId,
+
+    pub fn deinit(self: *UiCommand, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .OpenPanel => |*cmd| cmd.deinit(allocator),
+            .UpdatePanel => |*cmd| cmd.deinit(allocator),
+            .FocusPanel => {},
+            .ClosePanel => {},
+        }
+    }
+};
+
+pub const OpenPanelCmd = struct {
+    kind: workspace.PanelKind,
+    title: ?[]const u8 = null,
+    data: ?PanelDataPayload = null,
+
+    pub fn deinit(self: *OpenPanelCmd, allocator: std.mem.Allocator) void {
+        if (self.title) |title| allocator.free(title);
+        if (self.data) |*data| data.deinit(allocator);
+    }
+};
+
+pub const UpdatePanelCmd = struct {
+    id: workspace.PanelId,
+    title: ?[]const u8 = null,
+    data: PanelDataPayload,
+
+    pub fn deinit(self: *UpdatePanelCmd, allocator: std.mem.Allocator) void {
+        if (self.title) |title| allocator.free(title);
+        self.data.deinit(allocator);
+    }
+};
+
+pub const PanelDataPayload = union(enum) {
+    Chat: ChatPanelPayload,
+    CodeEditor: CodeEditorPanelPayload,
+    ToolOutput: ToolOutputPanelPayload,
+    Control: ControlPanelPayload,
+
+    pub fn deinit(self: *PanelDataPayload, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .Chat => |*chat| {
+                if (chat.session) |session| allocator.free(session);
+            },
+            .CodeEditor => |*editor| {
+                if (editor.file) |file| allocator.free(file);
+                if (editor.language) |lang| allocator.free(lang);
+                if (editor.content) |content| allocator.free(content);
+            },
+            .ToolOutput => |*out| {
+                if (out.tool_name) |name| allocator.free(name);
+                if (out.stdout) |stdout| allocator.free(stdout);
+                if (out.stderr) |stderr| allocator.free(stderr);
+            },
+            .Control => |*ctrl| {
+                if (ctrl.active_tab) |tab| allocator.free(tab);
+            },
+        }
+    }
+};
+
+pub const ChatPanelPayload = struct {
+    session: ?[]const u8 = null,
+};
+
+pub const CodeEditorPanelPayload = struct {
+    file: ?[]const u8 = null,
+    language: ?[]const u8 = null,
+    content: ?[]const u8 = null,
+};
+
+pub const ToolOutputPanelPayload = struct {
+    tool_name: ?[]const u8 = null,
+    stdout: ?[]const u8 = null,
+    stderr: ?[]const u8 = null,
+    exit_code: ?i32 = null,
+};
+
+pub const ControlPanelPayload = struct {
+    active_tab: ?[]const u8 = null,
+};
+
+pub fn parse(allocator: std.mem.Allocator, json: []const u8) !?UiCommand {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, json, .{}) catch return null;
+    defer parsed.deinit();
+
+    if (parsed.value != .object) return null;
+    const obj = parsed.value.object;
+    const type_val = obj.get("type") orelse return null;
+    if (type_val != .string) return null;
+
+    const type_str = type_val.string;
+    if (std.mem.eql(u8, type_str, "OpenPanel")) {
+        return parseOpen(allocator, obj);
+    }
+    if (std.mem.eql(u8, type_str, "UpdatePanel")) {
+        return parseUpdate(allocator, obj);
+    }
+    if (std.mem.eql(u8, type_str, "FocusPanel")) {
+        const id = parseId(obj.get("id") orelse return null) orelse return null;
+        return UiCommand{ .FocusPanel = id };
+    }
+    if (std.mem.eql(u8, type_str, "ClosePanel")) {
+        const id = parseId(obj.get("id") orelse return null) orelse return null;
+        return UiCommand{ .ClosePanel = id };
+    }
+
+    return null;
+}
+
+fn parseOpen(allocator: std.mem.Allocator, obj: std.json.ObjectMap) !?UiCommand {
+    const kind_val = obj.get("kind") orelse return null;
+    if (kind_val != .string) return null;
+    const kind = parsePanelKind(kind_val.string) orelse return null;
+
+    const title = parseStringDup(allocator, obj, "title");
+    errdefer if (title) |value| allocator.free(value);
+    const payload_obj = extractPayloadObject(obj);
+
+    const data = switch (kind) {
+        .Chat => blk: {
+            const session = parseStringDupFrom(allocator, obj, payload_obj, "session");
+            break :blk PanelDataPayload{ .Chat = .{ .session = session } };
+        },
+        .CodeEditor => blk: {
+            const file = parseStringDupFrom(allocator, obj, payload_obj, "file") orelse {
+                if (title) |value| allocator.free(value);
+                return null;
+            };
+            const language = parseStringDupFrom(allocator, obj, payload_obj, "language");
+            const content = parseStringDupFrom(allocator, obj, payload_obj, "content");
+            break :blk PanelDataPayload{ .CodeEditor = .{ .file = file, .language = language, .content = content } };
+        },
+        .ToolOutput => blk: {
+            const tool_name = parseStringDupFrom(allocator, obj, payload_obj, "tool_name") orelse
+                parseStringDupFrom(allocator, obj, payload_obj, "tool") orelse {
+                    if (title) |value| allocator.free(value);
+                    return null;
+                };
+            const stdout = parseStringDupFrom(allocator, obj, payload_obj, "stdout");
+            const stderr = parseStringDupFrom(allocator, obj, payload_obj, "stderr");
+            const exit_code = parseIntFrom(obj, payload_obj, "exit_code");
+            break :blk PanelDataPayload{ .ToolOutput = .{
+                .tool_name = tool_name,
+                .stdout = stdout,
+                .stderr = stderr,
+                .exit_code = exit_code,
+            } };
+        },
+        .Control => blk: {
+            const active_tab = parseStringDupFrom(allocator, obj, payload_obj, "active_tab");
+            break :blk PanelDataPayload{ .Control = .{ .active_tab = active_tab } };
+        },
+    };
+
+    return UiCommand{ .OpenPanel = .{ .kind = kind, .title = title, .data = data } };
+}
+
+fn parseUpdate(allocator: std.mem.Allocator, obj: std.json.ObjectMap) !?UiCommand {
+    const id_val = obj.get("id") orelse return null;
+    const id = parseId(id_val) orelse return null;
+    const title = parseStringDup(allocator, obj, "title");
+    errdefer if (title) |value| allocator.free(value);
+    const payload_obj = extractPayloadObject(obj);
+
+    const kind_val = obj.get("kind");
+    const kind = if (kind_val != null and kind_val.? == .string)
+        parsePanelKind(kind_val.?.string)
+    else
+        null;
+
+    if (kind) |resolved| {
+        const data = try parseDataPayloadForKind(allocator, obj, payload_obj, resolved, false);
+        return UiCommand{ .UpdatePanel = .{ .id = id, .title = title, .data = data } };
+    }
+
+    if (payload_obj != null) {
+        if (payload_obj.?.get("file") != null or payload_obj.?.get("content") != null) {
+            const data = try parseDataPayloadForKind(allocator, obj, payload_obj, .CodeEditor, true);
+            return UiCommand{ .UpdatePanel = .{ .id = id, .title = title, .data = data } };
+        }
+        if (payload_obj.?.get("stdout") != null or payload_obj.?.get("stderr") != null) {
+            const data = try parseDataPayloadForKind(allocator, obj, payload_obj, .ToolOutput, true);
+            return UiCommand{ .UpdatePanel = .{ .id = id, .title = title, .data = data } };
+        }
+        if (payload_obj.?.get("active_tab") != null) {
+            const data = try parseDataPayloadForKind(allocator, obj, payload_obj, .Control, true);
+            return UiCommand{ .UpdatePanel = .{ .id = id, .title = title, .data = data } };
+        }
+    } else {
+        if (obj.get("file") != null or obj.get("content") != null) {
+            const data = try parseDataPayloadForKind(allocator, obj, payload_obj, .CodeEditor, true);
+            return UiCommand{ .UpdatePanel = .{ .id = id, .title = title, .data = data } };
+        }
+        if (obj.get("stdout") != null or obj.get("stderr") != null) {
+            const data = try parseDataPayloadForKind(allocator, obj, payload_obj, .ToolOutput, true);
+            return UiCommand{ .UpdatePanel = .{ .id = id, .title = title, .data = data } };
+        }
+        if (obj.get("active_tab") != null) {
+            const data = try parseDataPayloadForKind(allocator, obj, payload_obj, .Control, true);
+            return UiCommand{ .UpdatePanel = .{ .id = id, .title = title, .data = data } };
+        }
+    }
+
+    if (title) |value| allocator.free(value);
+    return null;
+}
+
+fn parseDataPayloadForKind(
+    allocator: std.mem.Allocator,
+    obj: std.json.ObjectMap,
+    payload_obj: ?std.json.ObjectMap,
+    kind: workspace.PanelKind,
+    allow_partial: bool,
+) !PanelDataPayload {
+    switch (kind) {
+        .Chat => {
+            const session = parseStringDupFrom(allocator, obj, payload_obj, "session");
+            if (!allow_partial and session == null) return error.MissingPanelData;
+            return .{ .Chat = .{ .session = session } };
+        },
+        .CodeEditor => {
+            const file = parseStringDupFrom(allocator, obj, payload_obj, "file");
+            const language = parseStringDupFrom(allocator, obj, payload_obj, "language");
+            const content = parseStringDupFrom(allocator, obj, payload_obj, "content");
+            if (!allow_partial and file == null) {
+                if (language) |lang| allocator.free(lang);
+                if (content) |body| allocator.free(body);
+                return error.MissingPanelData;
+            }
+            return .{ .CodeEditor = .{ .file = file, .language = language, .content = content } };
+        },
+        .ToolOutput => {
+            const tool_name = parseStringDupFrom(allocator, obj, payload_obj, "tool_name") orelse
+                parseStringDupFrom(allocator, obj, payload_obj, "tool");
+            const stdout = parseStringDupFrom(allocator, obj, payload_obj, "stdout");
+            const stderr = parseStringDupFrom(allocator, obj, payload_obj, "stderr");
+            const exit_code = parseIntFrom(obj, payload_obj, "exit_code");
+            if (!allow_partial and tool_name == null) return error.MissingPanelData;
+            return .{ .ToolOutput = .{ .tool_name = tool_name, .stdout = stdout, .stderr = stderr, .exit_code = exit_code } };
+        },
+        .Control => {
+            const active_tab = parseStringDupFrom(allocator, obj, payload_obj, "active_tab");
+            if (!allow_partial and active_tab == null) return error.MissingPanelData;
+            return .{ .Control = .{ .active_tab = active_tab } };
+        },
+    }
+}
+
+fn parsePanelKind(label: []const u8) ?workspace.PanelKind {
+    if (std.mem.eql(u8, label, "Chat")) return .Chat;
+    if (std.mem.eql(u8, label, "CodeEditor")) return .CodeEditor;
+    if (std.mem.eql(u8, label, "ToolOutput")) return .ToolOutput;
+    if (std.mem.eql(u8, label, "Control")) return .Control;
+    return null;
+}
+
+fn parseId(val: std.json.Value) ?workspace.PanelId {
+    return switch (val) {
+        .integer => |num| @intCast(num),
+        .float => |num| @intFromFloat(num),
+        else => null,
+    };
+}
+
+fn extractPayloadObject(obj: std.json.ObjectMap) ?std.json.ObjectMap {
+    const data_val = obj.get("data") orelse return null;
+    if (data_val != .object) return null;
+    return data_val.object;
+}
+
+fn parseStringDup(allocator: std.mem.Allocator, obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = obj.get(key) orelse return null;
+    if (value != .string) return null;
+    return allocator.dupe(u8, value.string) catch null;
+}
+
+fn parseStringDupFrom(
+    allocator: std.mem.Allocator,
+    obj: std.json.ObjectMap,
+    payload_obj: ?std.json.ObjectMap,
+    key: []const u8,
+) ?[]const u8 {
+    if (payload_obj) |payload| {
+        if (payload.get(key)) |value| {
+            if (value == .string) return allocator.dupe(u8, value.string) catch null;
+        }
+    }
+    return parseStringDup(allocator, obj, key);
+}
+
+fn parseIntFrom(
+    obj: std.json.ObjectMap,
+    payload_obj: ?std.json.ObjectMap,
+    key: []const u8,
+) ?i32 {
+    if (payload_obj) |payload| {
+        if (payload.get(key)) |value| return parseInt(value);
+    }
+    if (obj.get(key)) |value| return parseInt(value);
+    return null;
+}
+
+fn parseInt(value: std.json.Value) ?i32 {
+    return switch (value) {
+        .integer => |num| @intCast(num),
+        .float => |num| @intFromFloat(num),
+        else => null,
+    };
+}

--- a/src/ui/ui_command_inbox.zig
+++ b/src/ui/ui_command_inbox.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const types = @import("../protocol/types.zig");
+const panel_manager = @import("panel_manager.zig");
+const ui_command = @import("ui_command.zig");
+
+pub const UiCommandInbox = struct {
+    processed_ids: std.StringHashMap(void),
+
+    pub fn init(allocator: std.mem.Allocator) UiCommandInbox {
+        return .{ .processed_ids = std.StringHashMap(void).init(allocator) };
+    }
+
+    pub fn deinit(self: *UiCommandInbox, allocator: std.mem.Allocator) void {
+        var it = self.processed_ids.iterator();
+        while (it.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+        }
+        self.processed_ids.deinit();
+    }
+
+    pub fn clear(self: *UiCommandInbox, allocator: std.mem.Allocator) void {
+        var it = self.processed_ids.iterator();
+        while (it.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+        }
+        self.processed_ids.clearRetainingCapacity();
+    }
+
+    pub fn collectFromMessages(
+        self: *UiCommandInbox,
+        allocator: std.mem.Allocator,
+        messages: []const types.ChatMessage,
+        manager: *panel_manager.PanelManager,
+    ) void {
+        for (messages) |msg| {
+            if (self.processed_ids.contains(msg.id)) continue;
+            if (!std.mem.eql(u8, msg.role, "assistant")) continue;
+            const cmd = ui_command.parse(allocator, msg.content) catch null;
+            if (cmd == null) continue;
+
+            var owned = cmd.?;
+            manager.applyUiCommand(owned) catch {};
+            owned.deinit(allocator);
+
+            const id_copy = allocator.dupe(u8, msg.id) catch continue;
+            self.processed_ids.put(id_copy, {}) catch allocator.free(id_copy);
+        }
+    }
+
+    pub fn isCommandMessage(self: *const UiCommandInbox, msg_id: []const u8) bool {
+        return self.processed_ids.contains(msg_id);
+    }
+};

--- a/src/ui/workspace.zig
+++ b/src/ui/workspace.zig
@@ -1,0 +1,468 @@
+const std = @import("std");
+const text_buffer = @import("text_buffer.zig");
+
+pub const PanelId = u64;
+pub const DockNodeId = u32;
+pub const ProjectId = u64;
+
+pub const PanelKind = enum {
+    Chat,
+    CodeEditor,
+    ToolOutput,
+    Control,
+};
+
+pub const PanelState = struct {
+    dock_node: DockNodeId = 0,
+    is_focused: bool = false,
+    is_dirty: bool = false,
+};
+
+pub const EditorOwner = enum { user, ai };
+
+pub const ChatPanel = struct {
+    session_key: ?[]const u8 = null,
+};
+
+pub const CodeEditorPanel = struct {
+    file_id: []const u8,
+    language: []const u8,
+    content: text_buffer.TextBuffer,
+    last_modified_by: EditorOwner = .ai,
+    version: u32 = 1,
+};
+
+pub const ToolOutputPanel = struct {
+    tool_name: []const u8,
+    stdout: text_buffer.TextBuffer,
+    stderr: text_buffer.TextBuffer,
+    exit_code: i32 = 0,
+};
+
+pub const ControlPanel = struct {
+    active_tab: ControlTab = .Sessions,
+};
+
+pub const ControlTab = enum {
+    Sessions,
+    Settings,
+    Operator,
+};
+
+pub const PanelData = union(enum) {
+    Chat: ChatPanel,
+    CodeEditor: CodeEditorPanel,
+    ToolOutput: ToolOutputPanel,
+    Control: ControlPanel,
+
+    pub fn deinit(self: *PanelData, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .Chat => |*chat| {
+                if (chat.session_key) |key| allocator.free(key);
+            },
+            .CodeEditor => |*editor| {
+                allocator.free(editor.file_id);
+                allocator.free(editor.language);
+                editor.content.deinit(allocator);
+            },
+            .ToolOutput => |*out| {
+                allocator.free(out.tool_name);
+                out.stdout.deinit(allocator);
+                out.stderr.deinit(allocator);
+            },
+            .Control => {},
+        }
+    }
+};
+
+pub const Panel = struct {
+    id: PanelId,
+    kind: PanelKind,
+    title: []const u8,
+    data: PanelData,
+    state: PanelState,
+
+    pub fn deinit(self: *Panel, allocator: std.mem.Allocator) void {
+        allocator.free(self.title);
+        self.data.deinit(allocator);
+    }
+};
+
+pub const DockLayout = struct {
+    imgui_ini: []u8,
+};
+
+pub const Workspace = struct {
+    panels: std.ArrayList(Panel),
+    layout: DockLayout,
+    focused_panel_id: ?PanelId,
+    active_project: ProjectId,
+    dirty: bool = false,
+
+    pub fn initEmpty(allocator: std.mem.Allocator) Workspace {
+        return .{
+            .panels = std.ArrayList(Panel).empty,
+            .layout = .{ .imgui_ini = allocator.dupe(u8, "") catch unreachable },
+            .focused_panel_id = null,
+            .active_project = 0,
+            .dirty = false,
+        };
+    }
+
+    pub fn initDefault(allocator: std.mem.Allocator) !Workspace {
+        var ws = Workspace.initEmpty(allocator);
+        try ws.panels.ensureTotalCapacity(allocator, 4);
+
+        try ws.panels.append(allocator, try makeControlPanel(allocator, 1));
+        try ws.panels.append(allocator, try makeCodeEditorPanel(allocator, 2, "main.zig", "zig", ""));
+        try ws.panels.append(allocator, try makeChatPanel(allocator, 3, null));
+        try ws.panels.append(allocator, try makeToolOutputPanel(allocator, 4, "Tool Output", "", "", 0));
+
+        ws.focused_panel_id = ws.panels.items[2].id;
+        return ws;
+    }
+
+    pub fn deinit(self: *Workspace, allocator: std.mem.Allocator) void {
+        for (self.panels.items) |*panel| {
+            panel.deinit(allocator);
+        }
+        self.panels.deinit(allocator);
+        allocator.free(self.layout.imgui_ini);
+    }
+
+    pub fn markDirty(self: *Workspace) void {
+        self.dirty = true;
+    }
+
+    pub fn markClean(self: *Workspace) void {
+        self.dirty = false;
+    }
+
+    pub fn toSnapshot(self: *const Workspace, allocator: std.mem.Allocator) !WorkspaceSnapshot {
+        var panels = try allocator.alloc(PanelSnapshot, self.panels.items.len);
+        var filled: usize = 0;
+        errdefer {
+            for (panels[0..filled]) |panel| {
+                freePanelSnapshot(allocator, panel);
+            }
+            allocator.free(panels);
+        }
+        for (self.panels.items, 0..) |panel, idx| {
+            panels[idx] = try panelToSnapshot(allocator, panel);
+            filled = idx + 1;
+        }
+        const layout_copy = try allocator.dupe(u8, self.layout.imgui_ini);
+        return .{
+            .active_project = self.active_project,
+            .focused_panel_id = self.focused_panel_id,
+            .layout_ini = layout_copy,
+            .panels = panels,
+        };
+    }
+
+    pub fn fromSnapshot(allocator: std.mem.Allocator, snapshot: WorkspaceSnapshot) !Workspace {
+        var ws = Workspace.initEmpty(allocator);
+        ws.active_project = snapshot.active_project;
+        ws.focused_panel_id = snapshot.focused_panel_id;
+
+        if (snapshot.layout_ini) |ini| {
+            allocator.free(ws.layout.imgui_ini);
+            ws.layout.imgui_ini = try allocator.dupe(u8, ini);
+        }
+
+        if (snapshot.panels) |panel_snaps| {
+            try ws.panels.ensureTotalCapacity(allocator, panel_snaps.len);
+            for (panel_snaps) |snap| {
+                try ws.panels.append(allocator, try panelFromSnapshot(allocator, snap));
+            }
+        }
+        return ws;
+    }
+};
+
+pub const PanelStateSnapshot = struct {
+    dock_node: DockNodeId = 0,
+    is_focused: bool = false,
+    is_dirty: bool = false,
+};
+
+pub const ChatPanelSnapshot = struct {
+    session: ?[]const u8 = null,
+};
+
+pub const CodeEditorPanelSnapshot = struct {
+    file_id: []const u8,
+    language: []const u8,
+    content: []const u8,
+    last_modified_by: []const u8 = "ai",
+    version: u32 = 1,
+};
+
+pub const ToolOutputPanelSnapshot = struct {
+    tool_name: []const u8,
+    stdout: []const u8,
+    stderr: []const u8,
+    exit_code: i32 = 0,
+};
+
+pub const ControlPanelSnapshot = struct {
+    active_tab: []const u8 = "Sessions",
+};
+
+pub const PanelSnapshot = struct {
+    id: PanelId,
+    kind: PanelKind,
+    title: []const u8,
+    state: PanelStateSnapshot = .{},
+    chat: ?ChatPanelSnapshot = null,
+    code_editor: ?CodeEditorPanelSnapshot = null,
+    tool_output: ?ToolOutputPanelSnapshot = null,
+    control: ?ControlPanelSnapshot = null,
+};
+
+pub const WorkspaceSnapshot = struct {
+    active_project: ProjectId = 0,
+    focused_panel_id: ?PanelId = null,
+    layout_ini: ?[]const u8 = null,
+    panels: ?[]PanelSnapshot = null,
+
+    pub fn deinit(self: *WorkspaceSnapshot, allocator: std.mem.Allocator) void {
+        if (self.layout_ini) |ini| allocator.free(ini);
+        if (self.panels) |panels| {
+            for (panels) |panel| {
+                freePanelSnapshot(allocator, panel);
+            }
+            allocator.free(panels);
+        }
+    }
+};
+
+fn panelToSnapshot(allocator: std.mem.Allocator, panel: Panel) !PanelSnapshot {
+    const title_copy = try allocator.dupe(u8, panel.title);
+    var snap = PanelSnapshot{
+        .id = panel.id,
+        .kind = panel.kind,
+        .title = title_copy,
+        .state = .{
+            .dock_node = panel.state.dock_node,
+            .is_focused = panel.state.is_focused,
+            .is_dirty = panel.state.is_dirty,
+        },
+    };
+    errdefer freePanelSnapshot(allocator, snap);
+
+    switch (panel.data) {
+        .Chat => |chat| {
+            snap.chat = .{ .session = if (chat.session_key) |key| try allocator.dupe(u8, key) else null };
+        },
+        .CodeEditor => |editor| {
+            snap.code_editor = .{
+                .file_id = try allocator.dupe(u8, editor.file_id),
+                .language = try allocator.dupe(u8, editor.language),
+                .content = try allocator.dupe(u8, editor.content.slice()),
+                .last_modified_by = if (editor.last_modified_by == .user)
+                    try allocator.dupe(u8, "user")
+                else
+                    try allocator.dupe(u8, "ai"),
+                .version = editor.version,
+            };
+        },
+        .ToolOutput => |out| {
+            snap.tool_output = .{
+                .tool_name = try allocator.dupe(u8, out.tool_name),
+                .stdout = try allocator.dupe(u8, out.stdout.slice()),
+                .stderr = try allocator.dupe(u8, out.stderr.slice()),
+                .exit_code = out.exit_code,
+            };
+        },
+        .Control => |ctrl| {
+            snap.control = .{ .active_tab = try allocator.dupe(u8, switch (ctrl.active_tab) {
+                .Sessions => "Sessions",
+                .Settings => "Settings",
+                .Operator => "Operator",
+            }) };
+        },
+    }
+
+    return snap;
+}
+
+fn panelFromSnapshot(allocator: std.mem.Allocator, snap: PanelSnapshot) !Panel {
+    const title_copy = try allocator.dupe(u8, snap.title);
+    errdefer allocator.free(title_copy);
+    const state_val = PanelState{
+        .dock_node = snap.state.dock_node,
+        .is_focused = snap.state.is_focused,
+        .is_dirty = snap.state.is_dirty,
+    };
+
+    switch (snap.kind) {
+        .Chat => {
+            const session_copy = if (snap.chat) |chat|
+                if (chat.session) |session| try allocator.dupe(u8, session) else null
+            else
+                null;
+            return .{
+                .id = snap.id,
+                .kind = .Chat,
+                .title = title_copy,
+                .data = .{ .Chat = .{ .session_key = session_copy } },
+                .state = state_val,
+            };
+        },
+        .CodeEditor => {
+            const ce = snap.code_editor orelse return error.MissingPanelData;
+            const file_id = try allocator.dupe(u8, ce.file_id);
+            const language = try allocator.dupe(u8, ce.language);
+            const content = try text_buffer.TextBuffer.init(allocator, ce.content);
+            const modified_by: EditorOwner = if (std.mem.eql(u8, ce.last_modified_by, "user"))
+                .user
+            else
+                .ai;
+            return .{
+                .id = snap.id,
+                .kind = .CodeEditor,
+                .title = title_copy,
+                .data = .{ .CodeEditor = .{
+                    .file_id = file_id,
+                    .language = language,
+                    .content = content,
+                    .last_modified_by = modified_by,
+                    .version = ce.version,
+                } },
+                .state = state_val,
+            };
+        },
+        .ToolOutput => {
+            const to = snap.tool_output orelse return error.MissingPanelData;
+            const tool_name = try allocator.dupe(u8, to.tool_name);
+            const stdout = try text_buffer.TextBuffer.init(allocator, to.stdout);
+            const stderr = try text_buffer.TextBuffer.init(allocator, to.stderr);
+            return .{
+                .id = snap.id,
+                .kind = .ToolOutput,
+                .title = title_copy,
+                .data = .{ .ToolOutput = .{
+                    .tool_name = tool_name,
+                    .stdout = stdout,
+                    .stderr = stderr,
+                    .exit_code = to.exit_code,
+                } },
+                .state = state_val,
+            };
+        },
+        .Control => {
+            const ctrl_snap = snap.control orelse ControlPanelSnapshot{};
+            const active_tab = parseControlTab(ctrl_snap.active_tab);
+            return .{
+                .id = snap.id,
+                .kind = .Control,
+                .title = title_copy,
+                .data = .{ .Control = .{ .active_tab = active_tab } },
+                .state = state_val,
+            };
+        },
+    }
+}
+
+fn parseControlTab(label: []const u8) ControlTab {
+    if (std.mem.eql(u8, label, "Settings")) return .Settings;
+    if (std.mem.eql(u8, label, "Operator")) return .Operator;
+    return .Sessions;
+}
+
+fn freePanelSnapshot(allocator: std.mem.Allocator, panel: PanelSnapshot) void {
+    allocator.free(panel.title);
+    if (panel.chat) |chat| {
+        if (chat.session) |session| allocator.free(session);
+    }
+    if (panel.code_editor) |editor| {
+        allocator.free(editor.file_id);
+        allocator.free(editor.language);
+        allocator.free(editor.content);
+        allocator.free(editor.last_modified_by);
+    }
+    if (panel.tool_output) |out| {
+        allocator.free(out.tool_name);
+        allocator.free(out.stdout);
+        allocator.free(out.stderr);
+    }
+    if (panel.control) |ctrl| {
+        allocator.free(ctrl.active_tab);
+    }
+}
+
+pub fn makeChatPanel(allocator: std.mem.Allocator, id: PanelId, session_key: ?[]const u8) !Panel {
+    const title = try allocator.dupe(u8, "Chat");
+    const session_copy = if (session_key) |key| try allocator.dupe(u8, key) else null;
+    return .{
+        .id = id,
+        .kind = .Chat,
+        .title = title,
+        .data = .{ .Chat = .{ .session_key = session_copy } },
+        .state = .{},
+    };
+}
+
+pub fn makeCodeEditorPanel(
+    allocator: std.mem.Allocator,
+    id: PanelId,
+    file_id: []const u8,
+    language: []const u8,
+    content: []const u8,
+) !Panel {
+    const title = try allocator.dupe(u8, file_id);
+    const file_copy = try allocator.dupe(u8, file_id);
+    const lang_copy = try allocator.dupe(u8, language);
+    const buffer = try text_buffer.TextBuffer.init(allocator, content);
+    return .{
+        .id = id,
+        .kind = .CodeEditor,
+        .title = title,
+        .data = .{ .CodeEditor = .{
+            .file_id = file_copy,
+            .language = lang_copy,
+            .content = buffer,
+            .last_modified_by = .ai,
+            .version = 1,
+        } },
+        .state = .{},
+    };
+}
+
+pub fn makeToolOutputPanel(
+    allocator: std.mem.Allocator,
+    id: PanelId,
+    tool_name: []const u8,
+    stdout: []const u8,
+    stderr: []const u8,
+    exit_code: i32,
+) !Panel {
+    const title = try allocator.dupe(u8, "Tool Output");
+    const tool_copy = try allocator.dupe(u8, tool_name);
+    const stdout_buf = try text_buffer.TextBuffer.init(allocator, stdout);
+    const stderr_buf = try text_buffer.TextBuffer.init(allocator, stderr);
+    return .{
+        .id = id,
+        .kind = .ToolOutput,
+        .title = title,
+        .data = .{ .ToolOutput = .{
+            .tool_name = tool_copy,
+            .stdout = stdout_buf,
+            .stderr = stderr_buf,
+            .exit_code = exit_code,
+        } },
+        .state = .{},
+    };
+}
+
+pub fn makeControlPanel(allocator: std.mem.Allocator, id: PanelId) !Panel {
+    const title = try allocator.dupe(u8, "Control");
+    return .{
+        .id = id,
+        .kind = .Control,
+        .title = title,
+        .data = .{ .Control = .{} },
+        .state = .{},
+    };
+}

--- a/src/ui/workspace_store.zig
+++ b/src/ui/workspace_store.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+const workspace = @import("workspace.zig");
+
+pub fn loadOrDefault(allocator: std.mem.Allocator, path: []const u8) !workspace.Workspace {
+    const file = std.fs.cwd().openFile(path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return workspace.Workspace.initDefault(allocator),
+        else => return err,
+    };
+    defer file.close();
+
+    const data = try file.readToEndAlloc(allocator, 8 * 1024 * 1024);
+    defer allocator.free(data);
+
+    var parsed = std.json.parseFromSlice(workspace.WorkspaceSnapshot, allocator, data, .{}) catch {
+        return workspace.Workspace.initDefault(allocator);
+    };
+    defer parsed.deinit();
+
+    const ws = try workspace.Workspace.fromSnapshot(allocator, parsed.value);
+    return ws;
+}
+
+pub fn save(allocator: std.mem.Allocator, path: []const u8, ws: *const workspace.Workspace) !void {
+    var snapshot = try ws.toSnapshot(allocator);
+    defer snapshot.deinit(allocator);
+
+    const json = try std.json.Stringify.valueAlloc(allocator, snapshot, .{});
+    defer allocator.free(json);
+
+    const file = try std.fs.cwd().createFile(path, .{ .truncate = true });
+    defer file.close();
+
+    try file.writeAll(json);
+}

--- a/tests/ui_tests.zig
+++ b/tests/ui_tests.zig
@@ -9,5 +9,60 @@ test "ui modules compile" {
     _ = moltbot.ui.main_window;
     _ = moltbot.ui.status_bar;
     _ = moltbot.ui.settings_view;
+    _ = moltbot.ui.workspace;
+    _ = moltbot.ui.panel_manager;
+    _ = moltbot.ui.ui_command;
+    _ = moltbot.ui.ui_command_inbox;
     try std.testing.expect(true);
+}
+
+test "workspace snapshot roundtrip" {
+    const allocator = std.testing.allocator;
+    var ws = try moltbot.ui.workspace.Workspace.initDefault(allocator);
+    defer ws.deinit(allocator);
+
+    var snapshot = try ws.toSnapshot(allocator);
+    defer snapshot.deinit(allocator);
+
+    var ws2 = try moltbot.ui.workspace.Workspace.fromSnapshot(allocator, snapshot);
+    defer ws2.deinit(allocator);
+
+    try std.testing.expectEqual(ws.panels.items.len, ws2.panels.items.len);
+    try std.testing.expectEqual(ws.panels.items[0].kind, ws2.panels.items[0].kind);
+}
+
+test "ui command parse open code editor" {
+    const allocator = std.testing.allocator;
+    const json = "{\"type\":\"OpenPanel\",\"kind\":\"CodeEditor\",\"file\":\"ui.zig\",\"language\":\"zig\",\"content\":\"hello\"}";
+    const cmd = try moltbot.ui.ui_command.parse(allocator, json) orelse return error.TestExpectedCommand;
+    var owned = cmd;
+    defer owned.deinit(allocator);
+
+    switch (owned) {
+        .OpenPanel => |open| {
+            try std.testing.expectEqual(moltbot.ui.workspace.PanelKind.CodeEditor, open.kind);
+        },
+        else => return error.TestExpectedCommand,
+    }
+}
+
+test "panel manager reuses code editor" {
+    const allocator = std.testing.allocator;
+    var ws = try moltbot.ui.workspace.Workspace.initDefault(allocator);
+    var manager = moltbot.ui.panel_manager.PanelManager.init(allocator, ws);
+    defer manager.deinit();
+
+    const json = "{\"type\":\"OpenPanel\",\"kind\":\"CodeEditor\",\"file\":\"main.zig\",\"language\":\"zig\",\"content\":\"updated\"}";
+    const cmd = try moltbot.ui.ui_command.parse(allocator, json) orelse return error.TestExpectedCommand;
+    var owned = cmd;
+    defer owned.deinit(allocator);
+    try manager.applyUiCommand(owned);
+
+    var found: usize = 0;
+    for (manager.workspace.panels.items) |panel| {
+        if (panel.kind == .CodeEditor and std.mem.eql(u8, panel.data.CodeEditor.file_id, "main.zig")) {
+            found += 1;
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 1), found);
 }


### PR DESCRIPTION
## Summary
- implement workspace/panel model with docked UI and persistence
- add UI command ingestion + hide command payloads from chat
- add code editor/tool output/control panels and ImGui ini bridge

## Testing
- /home/deano/projects/ziggy_starclaw/.tools/zig-0.15.2/zig build
- /home/deano/projects/ziggy_starclaw/.tools/zig-0.15.2/zig build -Dtarget=x86_64-windows-gnu
- source ./scripts/emsdk-env.sh && /home/deano/projects/ziggy_starclaw/.tools/zig-0.15.2/zig build -Dwasm=true
- /home/deano/projects/ziggy_starclaw/.tools/zig-0.15.2/zig build -Dandroid=true
