### PR TITLE
design: ziggy-core library extraction

### DIFF
--- a/docs/design/ui_theme_library_extraction.md
+++ b/docs/design/ui_theme_library_extraction.md
@@ -1,0 +1,139 @@
+# UI + Theme System Library Extraction Design
+
+## Goal
+Extract the UI and theme system into a proper, reusable library in a separate repository.
+
+## Current State
+
+### UI System (`src/ui/`)
+
+**Core UI:**
+- `theme_engine/` - Theming system with packs, profiles, stylesheets
+- `components/` - Reusable UI components
+- `widgets/` - Basic widgets (button, checkbox, text_input, etc.)
+- `input/` - Input handling (keyboard, mouse, SDL backend, navigation)
+- Layout system: `workspace.zig`, `panel_manager.zig`, docking
+
+**ZSC-Specific UI:**
+- `main_window.zig` - Main application window
+- `chat_view.zig`, `input_panel.zig` - Chat-specific UI
+- `agents_view.zig` - Agent management UI
+- `settings_view.zig` - Settings panel
+
+### Theme Engine (`src/ui/theme_engine/`)
+
+**Core (Reusable):**
+- `theme_engine.zig` - Main theming runtime
+- `schema.zig` - Theme schema definitions
+- `style_sheet.zig` - Style processing
+- `runtime.zig` - Runtime theme application
+- `profile.zig` - Theme profiles
+- `theme_package.zig` - Package loading
+
+## Design
+
+### Repository Structure (New Repo: `ziggy-ui`)
+
+```
+ziggy-ui/
+├── build.zig
+├── build.zig.zon
+├── src/
+│   ├── root.zig              # Main export
+│   ├── theme_engine.zig      # Core theming
+│   ├── schema.zig            # Theme schemas
+│   ├── style_sheet.zig       # Style processing
+│   ├── runtime.zig           # Theme runtime
+│   ├── profile.zig           # Profile management
+│   ├── package.zig           # Package loading
+│   └── widgets/
+│       ├── root.zig          # Widget exports
+│       ├── button.zig
+│       ├── checkbox.zig
+│       ├── text_input.zig
+│       └── text_editor.zig
+├── src/components/
+│   ├── root.zig              # Component exports
+│   └── composite/            # Complex components
+├── src/layout/
+│   ├── dock.zig              # Docking system
+│   ├── panel.zig             # Panel management
+│   └── workspace.zig         # Workspace layout
+└── themes/
+    ├── zsc_clean/            # Clean modern theme
+    ├── zsc_showcase/         # Showcase theme
+    └── zsc_winamp/           # Retro/winamp theme
+```
+
+### API Design Principles
+
+1. **Backend Agnostic** - Support multiple renderers (WGPU, SDL, etc.)
+2. **Input Abstraction** - Pluggable input backends
+3. **Theme-First** - Everything styled via theme system
+4. **Composability** - Easy to build complex UIs from simple parts
+
+### Dependencies
+
+**Required:**
+- `ziggy-core` - For protocol types, utils
+- Rendering backend (WGPU, etc.)
+- Input backend (SDL, etc.)
+
+**Optional:**
+- Font loading (FreeType)
+- Image loading
+
+### Versioning Strategy
+
+- Start at `0.1.0`
+- API stability at `1.0.0`
+- Theme format stability earlier (themes are data)
+
+### Migration Plan
+
+1. **Audit current UI** - Identify reusable vs ZSC-specific
+2. **Extract theme engine** - Move to new repo first
+3. **Extract widgets** - Basic widget set
+4. **Extract components** - Higher-level components
+5. **Extract layout** - Docking/workspace system
+6. **Update ZSC** - Import as package, remove from src/ui/
+
+### Separation Strategy
+
+**Move to Library:**
+- Theme engine (schema, runtime, packages)
+- Base widgets (button, checkbox, text input)
+- Layout system (dock, panels)
+- Input abstraction layer
+
+**Keep in ZSC:**
+- Application-specific views (chat, agents, settings)
+- Custom ZSC widgets
+- Main window shell
+
+## Open Questions (Answered)
+
+1. **Should rendering be part of UI lib or separate?**
+   - ✅ Keep it part of the UI lib for now - can refactor out later if needed
+
+2. **How to handle platform-specific code (Android, WASM)?**
+   - ✅ Keep it behind platform configs
+
+3. **Should input be a separate abstraction library?**
+   - ✅ Like renderer, keep it in for now
+
+4. **Package manager: git submodule vs zig package?**
+   - ✅ Use Zig package manager
+
+## Benefits
+
+- Reusable UI framework for other projects
+- Independent theme development
+- Easier to test UI components in isolation
+- Community can contribute themes
+
+## Risks
+
+- Large refactoring effort
+- Breaking changes during extraction
+- Coordination between two repos

--- a/docs/design/ziggy_core_library_extraction.md
+++ b/docs/design/ziggy_core_library_extraction.md
@@ -1,0 +1,101 @@
+# Ziggy-Core Library Extraction Design
+
+## Goal
+Extract `ziggy-core` into a proper, versioned, publishable library in a separate repository.
+
+## Current State
+
+`libs/core/` contains:
+- **protocol/**: chat, constants, gateway, messages, requests
+- **client/**: device_identity
+- **utils/**: logger, json_helpers, string_utils, secret_prompt, allocator
+
+Dependencies:
+- websocket (external dep)
+- build_options (from parent)
+
+## Design
+
+### Repository Structure (New Repo: `ziggy-core`)
+
+```
+ziggy-core/
+├── build.zig              # Library build file
+├── build.zig.zon          # Package manifest
+├── src/
+│   └── root.zig           # Main module export
+├── lib/
+│   ├── protocol/
+│   │   ├── chat.zig
+│   │   ├── constants.zig
+│   │   ├── gateway.zig
+│   │   ├── messages.zig
+│   │   └── requests.zig
+│   ├── client/
+│   │   └── identity.zig
+│   └── utils/
+│       ├── logger.zig
+│       ├── json_helpers.zig
+│       ├── string_utils.zig
+│       ├── secret_prompt.zig
+│       └── allocator.zig
+└── tests/
+    └── core_tests.zig
+```
+
+### Versioning Strategy
+
+- Follow Semantic Versioning (SemVer)
+- Start at `0.1.0` for initial extraction
+- Tag releases: `v0.1.0`, `v0.2.0`, etc.
+
+### Dependencies
+
+**Required:**
+- `websocket` - Already a dep, keep as external
+
+**To be removed/abstracted:**
+- `build_options` - Replace with compile-time config or feature flags
+
+### API Stability
+
+Phase 1: Internal API (v0.x)
+- APIs may change between minor versions
+- Focus on getting the extraction right
+
+Phase 2: Stable API (v1.0+)
+- Commit to backward compatibility
+- Document public API surface
+
+### Migration Plan
+
+1. **Setup new repo** with proper structure
+2. **Migrate code** from `libs/core/` to new repo
+3. **Update imports** in ZiggyStarClaw to use package
+4. **Add as git submodule** or zig package dependency
+5. **Remove `libs/core/`** from main repo
+6. **CI/CD** for the library
+
+### Open Questions (Answered)
+
+1. **Should profiler stay in core or move to ZSC-specific?**
+   - ✅ Keep in core for now
+
+2. **How to handle build_options dependency cleanly?**
+   - ⚠️ TBD (needs investigation)
+
+3. **Package manager: git submodule vs zig package manager?**
+   - ✅ Use Zig package manager
+
+## Benefits
+
+- Clean separation of concerns
+- Reusable core for other projects
+- Independent versioning
+- Easier testing of core logic
+
+## Risks
+
+- Initial migration effort
+- Dual maintenance during transition
+- Breaking changes in early versions


### PR DESCRIPTION
Design document for extracting ziggy-core into a proper library in a separate repository.

**Key points:**
- Clean module boundaries for protocol, client identity, utils
- SemVer versioning starting at 0.1.0
- Migration plan with 6 steps
- Open questions answered (see doc)

Replaces #191 which had merge conflicts.

/cc @DeanoC for review

Related: #24